### PR TITLE
Disable old code to build with uv python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,13 +112,14 @@ class BuildBases(setuptools.command.build_ext.build_ext):
                 extra_args.extend(get_config_var("LIBS").split())
             if get_config_var("LIBM"):
                 extra_args.append(get_config_var("LIBM"))
-            if get_config_var("BASEMODLIBS"):
-                extra_args.extend(get_config_var("BASEMODLIBS").split())
-            if get_config_var("LOCALMODLIBS"):
-                extra_args.extend(get_config_var("LOCALMODLIBS").split())
-                # fix for Python 3.12 Ubuntu Linux 24.04 (Noble Nimbat)
-                with contextlib.suppress(ValueError):
-                    extra_args.remove("Modules/_hacl/libHacl_Hash_SHA2.a")
+            if 0:
+                if get_config_var("BASEMODLIBS"):
+                    extra_args.extend(get_config_var("BASEMODLIBS").split())
+                if get_config_var("LOCALMODLIBS"):
+                    extra_args.extend(get_config_var("LOCALMODLIBS").split())
+                    # fix for Python 3.12 Ubuntu Linux 24.04 (Noble Nimbat)
+                    with contextlib.suppress(ValueError):
+                        extra_args.remove("Modules/_hacl/libHacl_Hash_SHA2.a")
             if IS_MACOS:
                 extra_args.append("-Wl,-export_dynamic")
                 extra_args.append("-Wl,-rpath,@loader_path/lib")


### PR DESCRIPTION
After the change, in Linux it continues to work with:
- Ubuntu 24.04 Python 3.12 (tested locally w/ pip install -e.)
- uv python 3.14 (tested locally w/ pip install -e.)
- manylinux 2_17 (2014) (tested w/ cibuildwheel on github and locally w/ pip install -e.)
- manylinux 2_28 (tested locally w/ pip install -e.)
- macOS (tested w/ cibuildwheel on github)