### PR TITLE
Support Python 3.15 beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,28 +32,28 @@ jobs:
       - name: Extra includes
         id: includes
         run: |
-          # Support Python 3.11 to 3.14 on major platforms
-          # Support Python 3.11 to 3.14 on lesser-known Linux platforms
-          # Support Python 3.11 to 3.14 on Windows ARM64 (win_arm64).
+          # Support Python 3.11 to 3.15 on major platforms
+          # Support Python 3.11 to 3.15 on lesser-known Linux platforms
+          # Support Python 3.11 to 3.15 on Windows ARM64 (win_arm64).
           import json, os
           include = [
               {
                   "os": "ubuntu",
                   "os-version": "latest",
                   "arch": "x86_64",
-                  "tag": "cp3{11,12,13,14,14t}-manylinux_x86_64",
+                  "tag": "cp3{11,12,13,14,14t,15,15t}-manylinux_x86_64",
               },
               {
                   "os": "windows",
                   "os-version": "latest",
                   "arch": "x86_64",
-                  "tag": "cp3{11,12,13,14,14t}-win_amd64",
+                  "tag": "cp3{11,12,13,14,14t,15,15t}-win_amd64",
               },
               {
                   "os": "macos",
                   "os-version": "15",
                   "arch": "universal2",
-                  "tag": "cp3{11,12,13,14,14t}-macosx_universal2",
+                  "tag": "cp3{11,12,13,14,14t,15,15t}-macosx_universal2",
               },
           ]
           if os.environ["EVENT_NAME"] != "pull_request":
@@ -62,37 +62,37 @@ jobs:
                     "os": "ubuntu",
                     "os-version": "latest",
                     "arch": "x86_64",
-                    "tag": "cp3{11,12,13,14,14t}-musllinux_x86_64",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-musllinux_x86_64",
                 },
                 {
                     "os": "ubuntu",
                     "os-version": "24.04-arm",
                     "arch": "arm64",
-                    "tag": "cp3{11,12,13,14,14t}-manylinux_aarch64",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-manylinux_aarch64",
                 },
                 {
                     "os": "ubuntu",
                     "os-version": "24.04-arm",
                     "arch": "arm64",
-                    "tag": "cp3{11,12,13,14,14t}-musllinux_aarch64",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-musllinux_aarch64",
                 },
                 {
                     "os": "ubuntu",
                     "os-version": "22.04",
                     "arch": "ppc64le",
-                    "tag": "cp3{11,12,13,14,14t}-manylinux_ppc64le",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-manylinux_ppc64le",
                 },
                 {
                     "os": "windows",
                     "os-version": "11-arm",
                     "arch": "arm64",
-                    "tag": "cp3{11,12,13,14,14t}-win_arm64",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-win_arm64",
                 },
                 {
                     "os": "windows",
                     "os-version": "latest",
                     "arch": "x86_64",
-                    "tag": "cp3{11,12,13,14,14t}-win32",
+                    "tag": "cp3{11,12,13,14,14t,15,15t}-win32",
                 },
             ]
           with open(os.environ["GITHUB_OUTPUT"], "a+") as f:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         os: [ubuntu, windows, macos]
         os_version: [latest]
         python-version:
-          ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
+          ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev", "3.15t-dev"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,8 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         os_version: [latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version:
+          ["3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
     defaults:
       run:
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ where = ["src"]
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build-verbosity = 1
+enable = "cpython-prerelease"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 aarch64 ppc64le"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
To help other projects prepare for Python 3.15, wheels are now built for the 3.15 beta as a preview. This is not official support for Python 3.15, but rather an opportunity for you to test how freeze-core (and cx_Freeze) work with the beta and report any problems.